### PR TITLE
removed the python 3 function annotation

### DIFF
--- a/PythonClient/AirSimClient.py
+++ b/PythonClient/AirSimClient.py
@@ -527,7 +527,7 @@ class MultirotorClient(AirSimClientBase, object):
 
         
     # query vehicle state
-    def getMultirotorState(self) -> MultirotorState:
+    def getMultirotorState(self):
         return MultirotorState.from_msgpack(self.client.call('getMultirotorState'))
     def getPosition(self):
         return Vector3r.from_msgpack(self.client.call('getPosition'))


### PR DESCRIPTION
The ros bridge requires Python 2, so it is incompatible with the latest version of AirSimClient.py, which uses a Python 3 function annotation on one line. I've removed the annotation to restore compatibility with Python 2.